### PR TITLE
[ingress] Support Internal IP

### DIFF
--- a/pkg/knctl/cmd/ingress_services.go
+++ b/pkg/knctl/cmd/ingress_services.go
@@ -158,7 +158,7 @@ func (s IngressServiceNodePort) Addresses() []string {
 	for _, node := range nodes.Items {
 		for _, addr := range node.Status.Addresses {
 			switch addr.Type {
-			case corev1.NodeHostName, corev1.NodeExternalIP, corev1.NodeExternalDNS:
+			case corev1.NodeHostName, corev1.NodeExternalIP, corev1.NodeExternalDNS, corev1.NodeInternalIP:
 				addrs = append(addrs, addr.Address)
 			}
 		}


### PR DESCRIPTION
On minikube with node port ingress:

    $ knctl curl --service hello
    Running: curl '-H' 'Host: hello.default.example.com' 'http://192.168.64.6:32380'