### PR TITLE
build flag "--template-kind cluster" to use ClusterBuildTemplate

### DIFF
--- a/docs/cmd/knctl_build_create.md
+++ b/docs/cmd/knctl_build_create.md
@@ -44,6 +44,7 @@ knctl build create [flags]
       --template string          Set template name
       --template-arg strings     Set template argument (format: key=value) (can be specified multiple times)
       --template-env strings     Set template environment variable (format: key=value) (can be specified multiple times)
+      --template-kind string     Set to 'cluster' to use ClusterBuildTemplate kind of templates
       --timeout duration         Set timeout for building stage (Knative Build has a 10m default)
 ```
 

--- a/docs/cmd/knctl_deploy.md
+++ b/docs/cmd/knctl_deploy.md
@@ -63,6 +63,7 @@ knctl deploy [flags]
       --template string                         Set template name
       --template-arg strings                    Set template argument (format: key=value) (can be specified multiple times)
       --template-env strings                    Set template environment variable (format: key=value) (can be specified multiple times)
+      --template-kind string                    Set to 'cluster' to use ClusterBuildTemplate kind of templates
       --watch-pod-logs                          Watch pod logs for new revision (default true)
   -l, --watch-pod-logs-indefinitely             Watch pod logs for new revision indefinitely
       --watch-revision-ready                    Wait for new revision to become ready (default true)

--- a/pkg/knctl/build/build_spec.go
+++ b/pkg/knctl/build/build_spec.go
@@ -40,7 +40,8 @@ type BuildSpecOpts struct {
 
 	ServiceAccountName string
 
-	Template     string
+	TemplateName string
+	TemplateKind string
 	TemplateArgs []string
 	TemplateEnv  []string
 
@@ -104,7 +105,7 @@ func (s BuildSpec) source(opts BuildSpecOpts) (*v1alpha1.SourceSpec, error) {
 }
 
 func (s BuildSpec) template(opts BuildSpecOpts) (*v1alpha1.TemplateInstantiationSpec, error) {
-	if len(opts.Template) == 0 {
+	if len(opts.TemplateName) == 0 {
 		return nil, nil
 	}
 
@@ -118,16 +119,21 @@ func (s BuildSpec) template(opts BuildSpecOpts) (*v1alpha1.TemplateInstantiation
 		return nil, err
 	}
 
+	templateKind := v1alpha1.BuildTemplateKind
+	if opts.TemplateKind == "cluster" || opts.TemplateKind == "Cluster" || opts.TemplateKind == "ClusterBuildTemplate" {
+		templateKind = v1alpha1.ClusterBuildTemplateKind
+	}
+
 	return &v1alpha1.TemplateInstantiationSpec{
-		Name:      opts.Template,
-		Kind:      "BuildTemplate",
+		Name:      opts.TemplateName,
+		Kind:      templateKind,
 		Arguments: args,
 		Env:       env,
 	}, nil
 }
 
 func (s BuildSpec) nonTemplateSteps(opts BuildSpecOpts) []corev1.Container {
-	if len(opts.Template) > 0 {
+	if len(opts.TemplateName) > 0 {
 		return nil
 	}
 

--- a/pkg/knctl/build/build_spec.go
+++ b/pkg/knctl/build/build_spec.go
@@ -120,6 +120,7 @@ func (s BuildSpec) template(opts BuildSpecOpts) (*v1alpha1.TemplateInstantiation
 
 	return &v1alpha1.TemplateInstantiationSpec{
 		Name:      opts.Template,
+		Kind:      "BuildTemplate",
 		Arguments: args,
 		Env:       env,
 	}, nil

--- a/pkg/knctl/build/build_spec_test.go
+++ b/pkg/knctl/build/build_spec_test.go
@@ -124,6 +124,7 @@ func TestBuildSpecWithCustomBuildTemplate(t *testing.T) {
 		},
 		Template: &v1alpha1.TemplateInstantiationSpec{
 			Name: "test-template",
+			Kind: "BuildTemplate",
 			Arguments: []v1alpha1.ArgumentSpec{
 				{
 					Name:  "test-template-arg-key",
@@ -139,6 +140,10 @@ func TestBuildSpecWithCustomBuildTemplate(t *testing.T) {
 				Value: "test-template-env-val",
 			}},
 		},
+	}
+
+	if !reflect.DeepEqual(spec.Template, expectedSpec.Template) {
+		t.Fatalf("Expect spec.template '%#v' to equal '%#v'", spec.Template, expectedSpec.Template)
 	}
 
 	if !reflect.DeepEqual(spec, expectedSpec) {

--- a/pkg/knctl/build/build_spec_test.go
+++ b/pkg/knctl/build/build_spec_test.go
@@ -105,7 +105,7 @@ func TestBuildSpecWithCustomBuildTemplate(t *testing.T) {
 		ServiceAccountName: "test-service-account",
 		GitURL:             "test-git-url",
 		GitRevision:        "test-git-revision",
-		Template:           "test-template",
+		TemplateName:       "test-template",
 		TemplateArgs:       []string{"test-template-arg-key=test-template-arg-val"},
 		TemplateEnv:        []string{"test-template-env-key=test-template-env-val"},
 		Image:              "test-image",
@@ -125,6 +125,58 @@ func TestBuildSpecWithCustomBuildTemplate(t *testing.T) {
 		Template: &v1alpha1.TemplateInstantiationSpec{
 			Name: "test-template",
 			Kind: "BuildTemplate",
+			Arguments: []v1alpha1.ArgumentSpec{
+				{
+					Name:  "test-template-arg-key",
+					Value: "test-template-arg-val",
+				},
+				{
+					Name:  "IMAGE",
+					Value: "test-image",
+				},
+			},
+			Env: []corev1.EnvVar{{
+				Name:  "test-template-env-key",
+				Value: "test-template-env-val",
+			}},
+		},
+	}
+
+	if !reflect.DeepEqual(spec.Template, expectedSpec.Template) {
+		t.Fatalf("Expect spec.template '%#v' to equal '%#v'", spec.Template, expectedSpec.Template)
+	}
+
+	if !reflect.DeepEqual(spec, expectedSpec) {
+		t.Fatalf("Expect spec '%#v' to equal '%#v'", spec, expectedSpec)
+	}
+}
+
+func TestBuildSpecWithCustomClusterBuildTemplate(t *testing.T) {
+	spec, err := ctlbuild.BuildSpec{}.Build(ctlbuild.BuildSpecOpts{
+		ServiceAccountName: "test-service-account",
+		GitURL:             "test-git-url",
+		GitRevision:        "test-git-revision",
+		TemplateName:       "test-template",
+		TemplateKind:       "cluster",
+		TemplateArgs:       []string{"test-template-arg-key=test-template-arg-val"},
+		TemplateEnv:        []string{"test-template-env-key=test-template-env-val"},
+		Image:              "test-image",
+	})
+	if err != nil {
+		t.Fatalf("Expected build spec to build successfully: %s", err)
+	}
+
+	expectedSpec := v1alpha1.BuildSpec{
+		ServiceAccountName: "test-service-account",
+		Source: &v1alpha1.SourceSpec{
+			Git: &v1alpha1.GitSourceSpec{
+				Url:      "test-git-url",
+				Revision: "test-git-revision",
+			},
+		},
+		Template: &v1alpha1.TemplateInstantiationSpec{
+			Name: "test-template",
+			Kind: "ClusterBuildTemplate",
 			Arguments: []v1alpha1.ArgumentSpec{
 				{
 					Name:  "test-template-arg-key",

--- a/pkg/knctl/cmd/build/create_flags.go
+++ b/pkg/knctl/cmd/build/create_flags.go
@@ -65,7 +65,8 @@ func (s *CreateArgsFlags) setWithPrefix(prefix string, cmd *cobra.Command, flags
 
 	cmd.Flags().StringVar(&s.ServiceAccountName, "service-account", "", "Set service account name for building") // TODO separate
 
-	cmd.Flags().StringVar(&s.Template, "template", "", "Set template name")
+	cmd.Flags().StringVar(&s.TemplateKind, "template-kind", "", "Set to 'cluster' to use ClusterBuildTemplate kind of templates")
+	cmd.Flags().StringVar(&s.TemplateName, "template", "", "Set template name")
 	cmd.Flags().StringSliceVar(&s.TemplateArgs, "template-arg", nil, "Set template argument (format: key=value) (can be specified multiple times)")
 	cmd.Flags().StringSliceVar(&s.TemplateEnv, "template-env", nil, "Set template environment variable (format: key=value) (can be specified multiple times)")
 


### PR DESCRIPTION
Both `knctl build create` and `knctl deploy` will support the use of knative 0.2 `ClusterBuildTemplate`:

```
knctl deploy -d . \
  --service knative-env \
  --service-account build \
  --template buildpack --template-kind=cluster \
  --image drnic/knative-env
```

Relates to https://github.com/knative/docs/pull/604