### PR TITLE
Fix docu

### DIFF
--- a/docs/deploy-custom-build-template.md
+++ b/docs/deploy-custom-build-template.md
@@ -33,7 +33,7 @@ $ knctl basic-auth-secret create -s docker-reg2 --docker-hub -u <your-username> 
 Create service account that references above credentials
 
 ```bash
-$ knctl service-account create -a serv-acct1 -s git1 -s docker-reg1 [-s docker-reg2]
+$ knctl service-account create -a serv-acct1 -s docker-reg1 [-s docker-reg2]
 ```
 
 Deploy service that builds image from a Git repo, and then deploys it

--- a/docs/deploy-source-directory.md
+++ b/docs/deploy-source-directory.md
@@ -33,7 +33,7 @@ $ knctl basic-auth-secret create -s docker-reg2 --docker-hub -u <your-username> 
 Create service account that references above credentials
 
 ```bash
-$ knctl service-account create -a serv-acct1 -s git1 -s docker-reg1 [-s docker-reg2]
+$ knctl service-account create -a serv-acct1 -s docker-reg1 [-s docker-reg2]
 ```
 
 Deploy service that builds image from a Git repo, and then deploys it


### PR DESCRIPTION
The `git1` secret belongs to a different doc (`deploy-private-git-repo.md`) and is not required for `deploy-custom-build-template.md` and `deploy-source-directory.md`.
