### PR TITLE
fix #49

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,3 +31,11 @@
   name = "k8s.io/code-generator"
   unused-packages = false
   non-go = false
+
+# Fix: #49
+#
+# NOTE:
+#   use of go-autorest v10.14.0
+[[override]]
+name = "github.com/Azure/go-autorest"
+revision = "bca49d5b51a50dc5bb17bbf6204c711c6dbded06"


### PR DESCRIPTION
Dive more into the issue and similar cases have fixed with the override of '_go-autorest_' dependency and use of _**v.0.14.0**_ as per the PR. 

Please see below for build a new clean copy:
```
$ dep ensure                                                                                                            
$ hack/build.sh                                                                                                        
+ go fmt ./cmd/... ./pkg/... ./test/...
+ go build ./cmd/...
+ ./knctl version
Client Version: 0.1.0

Succeeded
+ ./hack/generate-docs.sh
+ export KNCTL_NAMESPACE=
+ KNCTL_NAMESPACE=
+ export KNCTL_KUBECONFIG=
+ KNCTL_KUBECONFIG=
+ export KNCTL_BASIC_AUTH_SECRET_PASSWORD=
+ KNCTL_BASIC_AUTH_SECRET_PASSWORD=
+ export KNCTL_SSH_AUTH_SECRET_PRIVATE_KEY=
+ KNCTL_SSH_AUTH_SECRET_PRIVATE_KEY=
+ rm -rf docs/cmd
+ mkdir -p docs/cmd
+ go run ./hack/generate-docs.go
+ echo Success
Success
+ echo Success
Success
```