### PR TITLE
Typo: Corrected checksum algorithm number in kubectl-plugin.md

### DIFF
--- a/docs/kubectl-plugin.md
+++ b/docs/kubectl-plugin.md
@@ -17,7 +17,7 @@ $ ./kubectl version
 Install `knctl` by grabbing pre-built binaries from the [Releases page](https://github.com/cppforlife/knctl/releases)
 
 ```bash
-$ shasum -a 265 ~/Downloads/knctl-*
+$ shasum -a 256 ~/Downloads/knctl-*
 # Compare checksum output to what's included in the release notes
 
 $ mv ~/Downloads/knctl-* /usr/local/bin/kubectl-kn


### PR DESCRIPTION
In checksum command, algorithm is mistyped as 265 instead of 256